### PR TITLE
Fix missing location normalization helper

### DIFF
--- a/iproperty_extract_spyder.py
+++ b/iproperty_extract_spyder.py
@@ -1629,6 +1629,23 @@ def _normalize_address(s):
     return s
 
 
+def _normalize_location_text(value):
+    """Return a cleaned location string suitable for comparisons."""
+
+    if _is_blank(value):
+        return ""
+
+    text = _normalize_spaces(value)
+    if not text:
+        return ""
+
+    text = re.sub(r"\s*,\s*", ", ", text)
+    text = re.sub(r"\s*\|\s*", " | ", text)
+    text = text.strip(" ,-|•")
+    text = text.replace("&amp;", "&")
+    return text
+
+
 def extract_state_district(soup):
     state_candidates = []
     district_candidates = []


### PR DESCRIPTION
## Summary
- add a dedicated helper to normalize location text before extracting the state and district
- avoid runtime failures when state/district extraction calls the helper

## Testing
- python -m compileall iproperty_extract_spyder.py

------
https://chatgpt.com/codex/tasks/task_e_68e38f56c4cc8332af44d8b1492dbc30